### PR TITLE
Add .NET 8 API skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .serverless
 .idea
 undefined
+bin/
+obj/

--- a/Baltika.Api/Baltika.Api.csproj
+++ b/Baltika.Api/Baltika.Api.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/Baltika.Api/Baltika.Api.http
+++ b/Baltika.Api/Baltika.Api.http
@@ -1,0 +1,6 @@
+@Baltika.Api_HostAddress = http://localhost:5244
+
+GET {{Baltika.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/Baltika.Api/Modules/Budgets/Controllers/BudgetController.cs
+++ b/Baltika.Api/Modules/Budgets/Controllers/BudgetController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Budgets.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class BudgetController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetBudget()
+        {
+            return Ok(new { Message = "Budget info" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/Fixtures/Controllers/FixturesController.cs
+++ b/Baltika.Api/Modules/Fixtures/Controllers/FixturesController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Fixtures.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class FixturesController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetFixtures()
+        {
+            return Ok(new { Message = "List of fixtures" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/Negotiations/Controllers/NegotiationsController.cs
+++ b/Baltika.Api/Modules/Negotiations/Controllers/NegotiationsController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Negotiations.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class NegotiationsController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetNegotiations()
+        {
+            return Ok(new { Message = "List of negotiations" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/Players/Controllers/PlayersController.cs
+++ b/Baltika.Api/Modules/Players/Controllers/PlayersController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Players.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PlayersController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetPlayers()
+        {
+            return Ok(new { Message = "List of players" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/Seasons/Controllers/SeasonsController.cs
+++ b/Baltika.Api/Modules/Seasons/Controllers/SeasonsController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Seasons.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SeasonsController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetSeasons()
+        {
+            return Ok(new { Message = "List of seasons" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/Statistics/Controllers/StatisticsController.cs
+++ b/Baltika.Api/Modules/Statistics/Controllers/StatisticsController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Statistics.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class StatisticsController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetStatistics()
+        {
+            return Ok(new { Message = "Statistics" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/Teams/Controllers/TeamsController.cs
+++ b/Baltika.Api/Modules/Teams/Controllers/TeamsController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Teams.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TeamsController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetTeams()
+        {
+            return Ok(new { Message = "List of teams" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/Tournaments/Controllers/TournamentsController.cs
+++ b/Baltika.Api/Modules/Tournaments/Controllers/TournamentsController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.Tournaments.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TournamentsController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetTournaments()
+        {
+            return Ok(new { Message = "List of tournaments" });
+        }
+    }
+}

--- a/Baltika.Api/Modules/UsersAuth/Controllers/UsersController.cs
+++ b/Baltika.Api/Modules/UsersAuth/Controllers/UsersController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Baltika.Api.Modules.UsersAuth.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UsersController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetUsers()
+        {
+            return Ok(new { Message = "List of users" });
+        }
+    }
+}

--- a/Baltika.Api/Program.cs
+++ b/Baltika.Api/Program.cs
@@ -1,0 +1,18 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.MapControllers();
+
+app.Run();

--- a/Baltika.Api/Properties/launchSettings.json
+++ b/Baltika.Api/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:25680",
+      "sslPort": 44338
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5244",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7053;http://localhost:5244",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Baltika.Api/appsettings.Development.json
+++ b/Baltika.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Baltika.Api/appsettings.json
+++ b/Baltika.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# baltika-core
+# Baltika Modular Monolith
+
+This repository originally contained AWS Lambda functions written in Node.js. The project is being migrated to a modular monolith using **.NET 8**.
+
+## .NET API
+
+A new ASP.NET Core Web API project lives in the `Baltika.Api` folder. Modules are represented under `Baltika.Api/Modules` and include placeholder controllers for:
+
+- Users & Authentication
+- Teams
+- Players
+- Tournaments
+- Seasons
+- Fixtures & Matches
+- Negotiations & Auctions
+- Budgets
+- Statistics
+
+Run the API with:
+
+```bash
+cd Baltika.Api
+dotnet run
+```
+
+Swagger is enabled in development for easy exploration of the available endpoints.


### PR DESCRIPTION
## Summary
- initialize ASP.NET Core Web API in `Baltika.Api`
- add placeholder controllers for modular monolith
- ignore .NET build artifacts
- document how to run the new API in README

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6840eea8b1a8833392e5f30cf9c02304