### PR TITLE
Implement Teams endpoint using MySQL

### DIFF
--- a/Baltika.Api/Baltika.Api.csproj
+++ b/Baltika.Api/Baltika.Api.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Dapper" Version="2.1.38" />
+    <PackageReference Include="MySqlConnector" Version="2.3.8" />
   </ItemGroup>
 
 </Project>

--- a/Baltika.Api/Infrastructure/Database.cs
+++ b/Baltika.Api/Infrastructure/Database.cs
@@ -1,0 +1,18 @@
+using MySqlConnector;
+using System.Data;
+
+namespace Baltika.Api.Infrastructure;
+
+public static class Database
+{
+    public static MySqlConnection CreateConnection(IConfiguration configuration)
+    {
+        var host = Environment.GetEnvironmentVariable("DB_HOST") ?? configuration["Database:Host"];
+        var port = Environment.GetEnvironmentVariable("DB_PORT") ?? configuration["Database:Port"];
+        var user = Environment.GetEnvironmentVariable("DB_USER") ?? configuration["Database:User"];
+        var password = Environment.GetEnvironmentVariable("DB_PASSWORD") ?? configuration["Database:Password"];
+        var db = Environment.GetEnvironmentVariable("DB_NAME") ?? configuration["Database:Name"];
+        var connectionString = $"Server={host};Port={port};User ID={user};Password={password};Database={db};";
+        return new MySqlConnection(connectionString);
+    }
+}

--- a/Baltika.Api/Modules/Teams/Controllers/TeamsController.cs
+++ b/Baltika.Api/Modules/Teams/Controllers/TeamsController.cs
@@ -1,4 +1,7 @@
+using Dapper;
 using Microsoft.AspNetCore.Mvc;
+using Baltika.Api.Infrastructure;
+using MySqlConnector;
 
 namespace Baltika.Api.Modules.Teams.Controllers
 {
@@ -7,9 +10,13 @@ namespace Baltika.Api.Modules.Teams.Controllers
     public class TeamsController : ControllerBase
     {
         [HttpGet]
-        public IActionResult GetTeams()
+        public async Task<IActionResult> GetTeams([FromServices] IConfiguration configuration)
         {
-            return Ok(new { Message = "List of teams" });
+            using MySqlConnection connection = Database.CreateConnection(configuration);
+            await connection.OpenAsync();
+            var teams = await connection.QueryAsync(
+                "SELECT id, name, emblem, assistant, CAST(active AS UNSIGNED) AS active FROM teams");
+            return Ok(teams);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add database helper to connect to MySQL using environment variables
- install Dapper and MySqlConnector
- implement Teams API endpoint using Dapper

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: no project or solution file)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6840f2824b88833390bc33ad45d65e1e